### PR TITLE
Enable LTO and improve search speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "find-files"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -237,6 +238,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "find-files"
-version = "0.1.5"
+version = "0.1.6"
 description = "Find Files (ff) utility recursively searches the files whose names match the specified RegExp pattern in the provided directory (defaults to the current directory if not provided)."
 authors = ["Vishal Telangre <the@vishaltelangre.com>"]
 license = "Unlicense OR MIT"
 readme = "README.md"
 repository = "https://github.com/vishaltelangre/ff"
+
+[build-dependencies]
+lazy_static = "1.1.0"
+clap = "2.31.2"
 
 [dependencies]
 walkdir = "2"
@@ -18,12 +22,12 @@ num_cpus = "1.0"
 
 [dependencies.clap]
 version = "2.32"
-default-features = false
 features = [ "suggestions", "color" ]
-
-[build-dependencies]
-lazy_static = "1.1.0"
 
 [[bin]]
 name = "ff"
 path = "src/main.rs"
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,51 @@ Download the latest precompiled executable `ff` binary for your platform from th
 
 If you're a Rust programmer, download and install `ff` command using `cargo install find-files`. To update to a newer version, use the `--force` flag.
 
+# Benchmark Results
+
+```
+$ hyperfine                                \
+    --warmup 3                             \
+    --export-markdown benchmark-results.md \
+    "find . -iregex '.*[0-9]\.jpg$'"       \
+    "find . -iname '*[0-9].jpg'"           \
+    "fd -HI '.*[0-9]\.jpg$'"               \
+    "ff .*[0-9]\.jpg$"
+
+Benchmark #1: find . -iregex '.*[0-9]\.jpg$'
+  Time (mean ± σ):      42.8 ms ±   5.5 ms    [User: 11.7 ms, System: 30.1 ms]
+  Range (min … max):    31.2 ms …  56.9 ms    48 runs
+
+Benchmark #2: find . -iname '*[0-9].jpg'
+  Time (mean ± σ):      60.8 ms ±   7.2 ms    [User: 27.9 ms, System: 31.4 ms]
+  Range (min … max):    44.0 ms …  76.2 ms    37 runs
+
+Benchmark #3: fd -HI '.*[0-9]\.jpg$'
+  Time (mean ± σ):      18.8 ms ±   5.3 ms    [User: 14.9 ms, System: 19.9 ms]
+  Range (min … max):    11.2 ms …  41.6 ms    96 runs
+
+Benchmark #4: ff .*[0-9]\.jpg$
+  Time (mean ± σ):      18.7 ms ±   4.6 ms    [User: 15.7 ms, System: 22.5 ms]
+  Range (min … max):    11.7 ms …  30.4 ms    123 runs
+
+Summary
+  'ff .*[0-9]\.jpg$' ran
+    1.00 ± 0.37 times faster than 'fd -HI '.*[0-9]\.jpg$''
+    2.29 ± 0.63 times faster than 'find . -iregex '.*[0-9]\.jpg$''
+    3.25 ± 0.88 times faster than 'find . -iname '*[0-9].jpg'
+```
+
+| Command | Mean [ms] | Min…Max [ms] |
+|:---|---:|---:|
+| `find . -iregex '.*[0-9]\.jpg$'` | 42.8 ± 5.5 | 31.2…56.9 |
+| `find . -iname '*[0-9].jpg'` | 60.8 ± 7.2 | 44.0…76.2 |
+| `fd -HI '.*[0-9]\.jpg$'` | 18.8 ± 5.3 | 11.2…41.6 |
+| `ff .*[0-9]\.jpg$` | 18.7 ± 4.6 | 11.7…30.4 |
+
+Table: *benchmark-results.md*
+
+**NOTE:** Sometimes, `fd` is a bit faster than `ff` by approximately `1 ms` to `2 ms`.
+
 ## Usage
 
 ```
@@ -56,10 +101,10 @@ ARGS:
 There are a tons of possibilities to search files using `ff`.
 Following examples demonstrate just a tip of an iceberg.
 
-- List paths of files recursively in the current working directory matching `article_` string.
+- List paths of files recursively in the current working directory matching `article` string.
 
 ```
-ff article_
+ff article
 ```
 
 - List files having `.png`, or `.PNG` extension.

--- a/src/path_printer.rs
+++ b/src/path_printer.rs
@@ -29,7 +29,7 @@ impl<'a> PathPrinter<'a> {
             Some(result) => {
                 let matched_str = &self.path[result.start()..result.end()];
                 let colored_match = Green.bold().paint(matched_str).to_string();
-                let path = &self.path.replace(matched_str, &colored_match);
+                let path = self.path.replace(matched_str, &colored_match);
 
                 println!("{}", path);
             }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -35,15 +35,18 @@ impl<'a> Walker<'a> {
             Ok(())
         });
 
+        let working_dir_path = app::working_dir_path();
+
         walker.run(|| {
             let tx = tx.clone();
             let reg_exp = self.args.reg_exp.clone();
             let maybe_exclude_reg_exp = self.args.exclude_reg_exp.clone();
+            let working_dir_path = working_dir_path.clone();
 
             Box::new(move |path_entry| {
                 if let Ok(entry) = path_entry {
                     let path = entry.path().display().to_string();
-                    let path = truncate_working_dir_path(path);
+                    let path = truncate_working_dir_path(path, &working_dir_path);
 
                     if is_match(&reg_exp, &maybe_exclude_reg_exp, &path) {
                         match tx.send(path) {
@@ -81,9 +84,7 @@ fn is_match(reg_exp: &Regex, maybe_exclude_reg_exp: &Option<Regex>, path: &str) 
     }
 }
 
-fn truncate_working_dir_path(path: String) -> String {
-    let working_dir_path = app::working_dir_path();
-
+fn truncate_working_dir_path(path: String, working_dir_path: &str) -> String {
     if path.contains(&working_dir_path) {
         path.replace(&working_dir_path, ".")
     } else {


### PR DESCRIPTION
- LTO helps to speedup compile time and reduce binary size (Reference: https://github.com/johnthagen/min-sized-rust#enable-link-time-optimization-lto).
- Also, added benchmark results.