### PR TITLE
Replace `\` with `/` in path printer

### DIFF
--- a/src/path_printer.rs
+++ b/src/path_printer.rs
@@ -8,7 +8,9 @@ pub struct PathPrinter<'a> {
 }
 
 impl<'a> PathPrinter<'a> {
-    pub fn new(path: String, reg_exp: &Regex) -> PathPrinter {
+    pub fn new(mut path: String, reg_exp: &Regex) -> PathPrinter {
+        path = path.replace(r"\", "/");
+
         PathPrinter { path, reg_exp }
     }
 


### PR DESCRIPTION
When someone pipes output from this program, the backslashes are recognized as a special character.

For example, if I want to remove all exe files from the current directory, I would need to do something like that:
```sh
ff \.exe$ | sed s/\\/\//g | xargs rm
```
With this change I can do this:

```sh
ff \.exe$ | xargs rm
```